### PR TITLE
Adding proper UpToDateCheckInput for xaml files

### DIFF
--- a/CustomProjectSystem/CustomProject.targets
+++ b/CustomProjectSystem/CustomProject.targets
@@ -45,6 +45,7 @@
       <SubType>Designer</SubType>
     </Page>    
   
+    <UpToDateCheckInput Include="**\*.xaml" />
   </ItemGroup>  
   
   <!--


### PR DESCRIPTION
Sometime the up to date check of msbuild/vs2017 fails to detect changes in xaml files.
By adding `<UpToDateCheckInput Include="**\*.xaml" />` we ensure that those changes get picked up.